### PR TITLE
Update ev_iouring.c

### DIFF
--- a/ext/libev/ev_iouring.c
+++ b/ext/libev/ev_iouring.c
@@ -297,6 +297,7 @@ iouring_sqe_submit (EV_P_ struct io_uring_sqe *sqe)
   ++EV_SQ_VAR (tail);
   /*ECB_MEMORY_FENCE_RELEASE; /* for the time being we assume this is not needed */
   ++iouring_to_submit;
+  return 0;
 }
 
 /*****************************************************************************/
@@ -328,6 +329,7 @@ iouring_internal_destroy (EV_P)
       ev_ref (EV_A);
       ev_io_stop (EV_A_ &iouring_tfd_w);
     }
+  return 0;
 }
 
 ecb_cold


### PR DESCRIPTION
fixed 2 errors while auto-compiled with gem at default settings, gcc version 10.2.1
```
cc1: some warnings being treated as errors
```